### PR TITLE
Add mxnet as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mxnet"]
+	path = mxnet
+	url = https://github.com/dmlc/mxnet.git


### PR DESCRIPTION
Add mxnet as submodule, which is used to build `libmxent.so` and `mxnet-**.jar`.